### PR TITLE
Fix API exception handling - index 'error_description' isn't typicall…

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -156,7 +156,7 @@ class Client
                     $requestException->getMessage(),
                     $requestException->getCode(),
                     $requestException,
-                    $json['error_description']
+                    isset($json['message']) ? $json['message'] : null
                 );
                 throw $lnException;
             }
@@ -368,7 +368,7 @@ class Client
                 $requestException->getMessage(),
                 $requestException->getCode(),
                 $requestException,
-                $json['error_description']
+                isset($json['message']) ? $json['message'] : null
             );
             throw $lnException;
         }


### PR DESCRIPTION
…y found in API's response, but 'message' can be.

Whitespace changes.