### PR TITLE
Avoid getting the "Syntax error" from json_decode

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -308,10 +308,13 @@ class Client
      */
     public static function responseToArray($response)
     {
-        return \GuzzleHttp\json_decode(
-            $response->getBody()->getContents(),
-            true
-        );
+        if ($contents = $response->getBody()->getContents()) {
+            return \GuzzleHttp\json_decode(
+                $contents,
+                true
+            );
+        }
+        return array();
     }
 
     /**


### PR DESCRIPTION
Avoid getting the "Syntax error" from json_decode when LinkedIn API returns an empty response.