### PR TITLE
Update Client.php

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -308,10 +308,16 @@ class Client
      */
     public static function responseToArray($response)
     {
-        return \GuzzleHttp\json_decode(
-            $response->getBody()->getContents(),
-            true
-        );
+        if ($contents = $response->getBody()->getContents()) {
+            return \GuzzleHttp\json_decode(
+                $contents,
+                true
+            );
+        }
+        elseif ($contents = $response->getHeaders()) {
+                return $contents;
+        }
+        return array();
     }
 
     /**


### PR DESCRIPTION
> Linkedin does give response but it's in the header not body. We should parse the response correctly.

Hi, I'm facing the same error. I think the problem is that the current responseToArray method are prepared to parse the body, but this api call, has no body in the response, it just has a new header with the ucgPost Id, as @soisme told.

I've done a little change in the method, so we can return the headers, but I'm not sure if this change could break any other api call, because I just started to use this package.