### PR TITLE
Update Client.php for V2

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -81,7 +81,7 @@ class Client
      * Default API root URL
      * string
      */
-    const API_ROOT = 'https://api.linkedin.com/v1/';
+    const API_ROOT = 'https://api.linkedin.com/v2/';
 
     /**
      * API Root URL
@@ -131,6 +131,7 @@ class Client
     protected $apiHeaders = [
         'Content-Type' => 'application/json',
         'x-li-format' => 'json',
+        'X-Restli-Protocol-Version' => '2.0.0',
     ];
 
     /**


### PR DESCRIPTION
Since v1 is no longer supported by LinkedIn, I suppose the updates from [here](https://github.com/zoonman/linkedin-api-php-client/issues/31#issuecomment-448635157) could be put in the client itself.