### PR TITLE
 Upgrade headers to versioned API 202208

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -81,7 +81,7 @@ class Client
      * Default API root URL
      * string
      */
-    const API_ROOT = 'https://api.linkedin.com/v2/';
+    const API_ROOT = 'https://api.linkedin.com/rest/';
 
     /**
      * API Root URL
@@ -131,6 +131,7 @@ class Client
     protected $apiHeaders = [
         'Content-Type' => 'application/json',
         'x-li-format' => 'json',
+        'LinkedIn-Version' => '202208',
     ];
 
     /**


### PR DESCRIPTION
The Linkedin API now uses versioning and will deprecate the legacy version on Feb, 28. 

I have migrated using `setApiHeaders`, but so not everyone has to read up on this themselves, I am creating this PR. 

What I have tested already:
- [x] Create a posts
- [x] Upload assets
- [x] Login with Linkedin
- [x] Read profile / group data

Some more testing for deprecations might be needed.

Sources:
https://www.linkedin.com/developers/news/featured-updates/versioning-content-launch
https://learn.microsoft.com/en-us/linkedin/marketing/versioning

For everyone else reading this:
``` PHP
// Change the API endpoint to the new versioned endpoint
$this->client->setApiRoot("https://api.linkedin.com/rest/");

// Set the API headers to use the new versioning
$this->client->setApiHeaders([
    'Content-Type' => 'application/json',
    'x-li-format' => 'json',
    "LinkedIn-Version" => "202208",
]);```